### PR TITLE
Enhance Auth Pages with Consistent Navigation and Improved UX

### DIFF
--- a/app/components/button.tsx
+++ b/app/components/button.tsx
@@ -22,7 +22,7 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "px-4 py-2 md:px-6.5 md:py-3 md:text-lg",
+        default: "px-4 py-2 md:px-6.5 md:py-3 py-3 md:text-lg",
         sm: "h-9 rounded-md px-3",
         lg: "h-16 rounded-md px-8",
         icon: "h-10 w-10",

--- a/app/components/navigation.tsx
+++ b/app/components/navigation.tsx
@@ -11,6 +11,11 @@ import { LuX } from "react-icons/lu";
 import { Link } from "react-router";
 import { usePublicAuth } from "~/marketing/components/auth/public-auth-provider";
 
+interface NavigationProps {
+  hideAuthButtons?: boolean;
+  showHomeButton?: boolean;
+}
+
 const links = [
   {
     title: "Features",
@@ -29,9 +34,22 @@ const links = [
     href: "/about-us",
   },
 ];
-const Navigation = () => {
+
+const Navigation = ({ hideAuthButtons = false, showHomeButton = false }: NavigationProps) => {
   const [open, setOpen] = useState(false);
-  const { openSignIn, openSignUp } = usePublicAuth();
+  
+  // Safely handle auth context - might not be available in auth layouts
+  let openSignIn = () => {};
+  let openSignUp = () => {};
+  
+  try {
+    const { openSignIn: contextSignIn, openSignUp: contextSignUp } = usePublicAuth();
+    openSignIn = contextSignIn;
+    openSignUp = contextSignUp;
+  } catch (error) {
+    // usePublicAuth not available (e.g., in auth layout) - use empty functions
+    console.log('PublicAuthProvider not available, auth buttons will be hidden or non-functional');
+  }
   return (
     <>
       <div className="container flex items-center justify-between py-4 xl:py-6">
@@ -57,10 +75,19 @@ const Navigation = () => {
               </Link>
             ))}
           </div>
-          <div className="flex gap-3 shrink-0">
-            <Button variant="outline" onClick={openSignIn}>Sign In</Button>
-            <Button onClick={openSignUp}>Get Started</Button>
-          </div>
+          {!hideAuthButtons && (
+            <div className="flex gap-3 shrink-0">
+              <Button variant="outline" onClick={openSignIn}>Sign In</Button>
+              <Button onClick={openSignUp}>Get Started</Button>
+            </div>
+          )}
+          {showHomeButton && (
+            <div className="flex gap-3 shrink-0">
+              <Link to="/">
+                <Button variant="outline">Home</Button>
+              </Link>
+            </div>
+          )}
         </div>
 
         <div className="lg:hidden">
@@ -134,27 +161,38 @@ const Navigation = () => {
                         {link.title}
                       </Link>
                     ))}
-                    <div className="flex flex-col gap-3 mt-6 px-4">
-                      <Button 
-                        variant="outline" 
-                        className="w-full" 
-                        onClick={() => {
-                          setOpen(false);
-                          openSignIn();
-                        }}
-                      >
-                        Sign In
-                      </Button>
-                      <Button 
-                        className="w-full" 
-                        onClick={() => {
-                          setOpen(false);
-                          openSignUp();
-                        }}
-                      >
-                        Get Started
-                      </Button>
-                    </div>
+                    {!hideAuthButtons && (
+                      <div className="flex flex-col gap-3 mt-6 px-4">
+                        <Button 
+                          variant="outline" 
+                          className="w-full" 
+                          onClick={() => {
+                            setOpen(false);
+                            openSignIn();
+                          }}
+                        >
+                          Sign In
+                        </Button>
+                        <Button 
+                          className="w-full" 
+                          onClick={() => {
+                            setOpen(false);
+                            openSignUp();
+                          }}
+                        >
+                          Get Started
+                        </Button>
+                      </div>
+                    )}
+                    {showHomeButton && (
+                      <div className="flex flex-col gap-3 mt-6 px-4">
+                        <Link to="/" onClick={() => setOpen(false)}>
+                          <Button variant="outline" className="w-full">
+                            Home
+                          </Button>
+                        </Link>
+                      </div>
+                    )}
                   </div>
                 </div>
               </DialogPanel>

--- a/app/components/ui/select.tsx
+++ b/app/components/ui/select.tsx
@@ -21,7 +21,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-gray-300 bg-white px-3 py-2 text-sm ring-offset-white placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-10 w-full items-center justify-between rounded-md border border-gray-300 bg-white px-3 py-2 text-sm placeholder:text-gray-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
     {...props}

--- a/app/components/ui/textarea.tsx
+++ b/app/components/ui/textarea.tsx
@@ -1,0 +1,24 @@
+import * as React from "react"
+
+import { cn } from "~/lib/utils"
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Textarea.displayName = "Textarea"
+
+export { Textarea }

--- a/app/components/ui/tooltip.tsx
+++ b/app/components/ui/tooltip.tsx
@@ -1,0 +1,28 @@
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "~/lib/utils"
+
+const TooltipProvider = TooltipPrimitive.Provider
+
+const Tooltip = TooltipPrimitive.Root
+
+const TooltipTrigger = TooltipPrimitive.Trigger
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className
+    )}
+    {...props}
+  />
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/app/contributor/auth/login.tsx
+++ b/app/contributor/auth/login.tsx
@@ -24,7 +24,7 @@ export default function ContributorLogin() {
   };
 
   return (
-    <div className="min-h-screen flex flex-col-reverse lg:flex-row">
+    <div className="h-[90vh] flex flex-col-reverse lg:flex-row">
       {/* Left Side - Content */}
       <div className="flex-1 bg-gradient-to-br from-blue-50 to-green-50 p-4 sm:p-6 md:p-8 lg:p-12 xl:p-20 flex flex-col justify-center relative overflow-hidden">
         {/* Health-themed background illustration */}
@@ -42,7 +42,7 @@ export default function ContributorLogin() {
         
         <div className="max-w-xl mx-auto lg:mx-0 relative z-10">
           <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-4 sm:mb-6 text-balance leading-tight">
-            Share Trusted Health Expertise
+            Share Knowledge. Inspire Change
           </h1>
           <p className="text-base sm:text-lg mb-6 sm:mb-8 leading-relaxed text-balance text-gray-600">
             Amplify your voice across Africa and beyond. Counter misinformation with trusted insights and help shape healthier communities.

--- a/app/contributor/auth/login.tsx
+++ b/app/contributor/auth/login.tsx
@@ -1,59 +1,127 @@
-export default function ContributorLogin() {
-  return (
-    <div className="max-w-md w-full">
-      <div className="text-center mb-8">
-        <h1 className="text-3xl font-bold text-gray-900">Contributor Login</h1>
-        <p className="text-gray-600 mt-2">Access your contributor dashboard</p>
-      </div>
+"use client"
 
-      <form className="space-y-6">
-        <div>
-          <label className="block text-sm font-medium text-gray-700">Email Address</label>
-          <input 
-            type="email" 
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" 
-            placeholder="contributor@email.com" 
-          />
+import { useState } from "react";
+import Button from "~/components/button";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { Eye, EyeOff } from "lucide-react";
+
+export default function ContributorLogin() {
+  const [showPassword, setShowPassword] = useState(false);
+  const [formData, setFormData] = useState({
+    email: "",
+    password: "",
+  });
+
+  const handleInputChange = (field: string, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    console.log("Contributor login:", formData);
+    // Ready for API integration
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col-reverse lg:flex-row">
+      {/* Left Side - Content */}
+      <div className="flex-1 bg-gradient-to-br from-blue-50 to-green-50 p-4 sm:p-6 md:p-8 lg:p-12 xl:p-20 flex flex-col justify-center relative overflow-hidden">
+        {/* Health-themed background illustration */}
+        <div className="absolute inset-0 opacity-10">
+          <svg className="absolute top-10 left-10 w-20 h-20 text-blue-500" fill="currentColor" viewBox="0 0 20 20">
+            <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-8.293l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 001.414 1.414L9 9.414V13a1 1 0 102 0V9.414l1.293 1.293a1 1 0 001.414-1.414z" clipRule="evenodd" />
+          </svg>
+          <svg className="absolute bottom-20 right-16 w-16 h-16 text-green-500" fill="currentColor" viewBox="0 0 20 20">
+            <path fillRule="evenodd" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" clipRule="evenodd" />
+          </svg>
+          <svg className="absolute top-1/2 right-1/4 w-12 h-12 text-blue-400" fill="currentColor" viewBox="0 0 20 20">
+            <path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
         </div>
         
-        <div>
-          <label className="block text-sm font-medium text-gray-700">Password</label>
-          <input 
-            type="password" 
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" 
-            placeholder="••••••••" 
-          />
-        </div>
+        <div className="max-w-xl mx-auto lg:mx-0 relative z-10">
+          <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-4 sm:mb-6 text-balance leading-tight">
+            Share Trusted Health Expertise
+          </h1>
+          <p className="text-base sm:text-lg mb-6 sm:mb-8 leading-relaxed text-balance text-gray-600">
+            Amplify your voice across Africa and beyond. Counter misinformation with trusted insights and help shape healthier communities.
+          </p>
 
-        <div className="flex items-center justify-between">
-          <div className="flex items-center">
-            <input 
-              type="checkbox" 
-              className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded" 
-            />
-            <label className="ml-2 block text-sm text-gray-900">Remember me</label>
+          <div className="space-y-3 mb-8 sm:mb-12">
+            <div className="flex items-center gap-3">
+              <div className="w-2 h-2 bg-green-500 rounded-full"></div>
+              <span className="text-gray-700">Reach wider audiences with your expertise</span>
+            </div>
+            <div className="flex items-center gap-3">
+              <div className="w-2 h-2 bg-blue-500 rounded-full"></div>
+              <span className="text-gray-700">Collaborate with healthcare peers</span>
+            </div>
+            <div className="flex items-center gap-3">
+              <div className="w-2 h-2 bg-green-500 rounded-full"></div>
+              <span className="text-gray-700">Combat health misinformation</span>
+            </div>
           </div>
-          
-          <a href="#" className="text-sm text-blue-600 hover:text-blue-800">
-            Forgot password?
-          </a>
         </div>
+      </div>
 
-        <button 
-          type="submit"
-          className="w-full bg-blue-600 text-white py-3 rounded-md hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-        >
-          Sign In
-        </button>
-      </form>
+      {/* Right Side - Form */}
+      <div className="flex-1 bg-green-50 p-4 sm:p-6 md:p-8 lg:p-12 xl:p-20 flex flex-col justify-center">
+        <div className="max-w-md w-full mx-auto">
+          <form onSubmit={handleSubmit} className="space-y-4 sm:space-y-6">
+            <h2 className="text-2xl sm:text-3xl font-bold mb-6 sm:mb-8">Contributor Log in</h2>
 
-      <div className="mt-6 text-center">
-        <p className="text-sm text-gray-600">
-          Need a contributor account?{' '}
-          <a href="/contributor/auth/signup" className="text-blue-600 hover:text-blue-800">
-            Request an invitation
-          </a>
-        </p>
+            <div className="space-y-2">
+              <Label htmlFor="email" className="text-sm sm:text-base font-medium">
+                Email/Contributor ID
+              </Label>
+              <Input
+                id="email"
+                type="text"
+                placeholder="Enter your email/contributor id"
+                value={formData.email}
+                onChange={(e) => handleInputChange("email", e.target.value)}
+                className="h-10 sm:h-12 bg-white border-gray-300 text-sm sm:text-base"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="password" className="text-sm sm:text-base font-medium">
+                Password
+              </Label>
+              <div className="relative">
+                <Input
+                  id="password"
+                  type={showPassword ? "text" : "password"}
+                  placeholder="Enter your password"
+                  value={formData.password}
+                  onChange={(e) => handleInputChange("password", e.target.value)}
+                  className="h-10 sm:h-12 bg-white border-gray-300 text-sm sm:text-base pr-12"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(!showPassword)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+                >
+                  {showPassword ? <EyeOff className="h-4 w-4 sm:h-5 sm:w-5" /> : <Eye className="h-4 w-4 sm:h-5 sm:w-5" />}
+                </button>
+              </div>
+            </div>
+
+            <div>
+              <a href="#" className="text-blue-600 hover:text-blue-800 hover:underline text-xs sm:text-sm font-medium">
+                Forgot Password?
+              </a>
+            </div>
+
+            <Button
+              type="submit"
+              className="w-full"
+            >
+              Log in
+            </Button>
+          </form>
+        </div>
       </div>
     </div>
   );

--- a/app/contributor/auth/signup.tsx
+++ b/app/contributor/auth/signup.tsx
@@ -1,92 +1,180 @@
+"use client"
+
+import { useState } from "react";
+import Button from "~/components/button";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { Eye, EyeOff } from "lucide-react";
+
 export default function ContributorSignup() {
+  const [showPassword, setShowPassword] = useState(false);
+  const [formData, setFormData] = useState({
+    invitationCode: "",
+    fullName: "",
+    email: "",
+    password: "",
+    confirmPassword: "",
+  });
+
+  const handleInputChange = (field: string, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    console.log("Contributor signup:", formData);
+    // Ready for API integration
+  };
+
   return (
-    <div className="max-w-md w-full">
-      <div className="text-center mb-8">
-        <h1 className="text-3xl font-bold text-gray-900">Contributor Signup</h1>
-        <p className="text-gray-600 mt-2">Join our community of contributors</p>
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-green-50 flex items-center justify-center p-4 sm:p-6 md:p-8">
+      {/* Health-themed background illustration */}
+      <div className="absolute inset-0 opacity-10">
+        <svg className="absolute top-10 left-10 w-20 h-20 text-blue-500" fill="currentColor" viewBox="0 0 20 20">
+          <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-8.293l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 001.414 1.414L9 9.414V13a1 1 0 102 0V9.414l1.293 1.293a1 1 0 001.414-1.414z" clipRule="evenodd" />
+        </svg>
+        <svg className="absolute bottom-20 right-16 w-16 h-16 text-green-500" fill="currentColor" viewBox="0 0 20 20">
+          <path fillRule="evenodd" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" clipRule="evenodd" />
+        </svg>
+        <svg className="absolute top-1/2 right-1/4 w-12 h-12 text-blue-400" fill="currentColor" viewBox="0 0 20 20">
+          <path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
       </div>
 
-      <div className="bg-blue-50 border border-blue-200 rounded-md p-4 mb-6">
-        <div className="flex">
-          <div className="ml-3">
-            <h3 className="text-sm font-medium text-blue-800">Invitation Required</h3>
-            <div className="mt-2 text-sm text-blue-700">
-              <p>Contributor accounts require an invitation. Please enter your invitation code below.</p>
+      <div className="w-full max-w-md bg-white rounded-lg shadow-lg p-6 sm:p-8 relative z-10">
+        <div className="text-center mb-6 sm:mb-8">
+          <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">Contributor Signup</h1>
+          <p className="text-gray-600">Join our community of contributors</p>
+        </div>
+
+        <div className="bg-blue-50 border border-blue-200 rounded-md p-4 mb-6">
+          <div className="flex">
+            <div className="ml-3">
+              <h3 className="text-sm font-medium text-blue-800">Invitation Required</h3>
+              <div className="mt-2 text-sm text-blue-700">
+                <p>Contributor accounts require an invitation. Please enter your invitation code below.</p>
+              </div>
             </div>
           </div>
         </div>
-      </div>
 
-      <form className="space-y-6">
-        <div>
-          <label className="block text-sm font-medium text-gray-700">Invitation Code</label>
-          <input 
-            type="text" 
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" 
-            placeholder="Enter your invitation code" 
-          />
-        </div>
+        <form onSubmit={handleSubmit} className="space-y-4 sm:space-y-6">
+          <div className="space-y-2">
+            <Label htmlFor="invitationCode" className="text-sm sm:text-base font-medium">
+              Invitation Code
+            </Label>
+            <Input
+              id="invitationCode"
+              type="text"
+              placeholder="Enter your invitation code"
+              value={formData.invitationCode}
+              onChange={(e) => handleInputChange("invitationCode", e.target.value)}
+              className="h-10 sm:h-12 bg-white border-gray-300 text-sm sm:text-base"
+            />
+          </div>
 
-        <div>
-          <label className="block text-sm font-medium text-gray-700">Full Name</label>
-          <input 
-            type="text" 
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" 
-            placeholder="Your full name" 
-          />
-        </div>
-        
-        <div>
-          <label className="block text-sm font-medium text-gray-700">Email Address</label>
-          <input 
-            type="email" 
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" 
-            placeholder="your.email@example.com" 
-          />
-        </div>
-        
-        <div>
-          <label className="block text-sm font-medium text-gray-700">Password</label>
-          <input 
-            type="password" 
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" 
-            placeholder="••••••••" 
-          />
-        </div>
+          <div className="space-y-2">
+            <Label htmlFor="fullName" className="text-sm sm:text-base font-medium">
+              Full Name
+            </Label>
+            <Input
+              id="fullName"
+              type="text"
+              placeholder="Your full name"
+              value={formData.fullName}
+              onChange={(e) => handleInputChange("fullName", e.target.value)}
+              className="h-10 sm:h-12 bg-white border-gray-300 text-sm sm:text-base"
+            />
+          </div>
 
-        <div>
-          <label className="block text-sm font-medium text-gray-700">Confirm Password</label>
-          <input 
-            type="password" 
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" 
-            placeholder="••••••••" 
-          />
+          <div className="space-y-2">
+            <Label htmlFor="email" className="text-sm sm:text-base font-medium">
+              Email Address
+            </Label>
+            <Input
+              id="email"
+              type="email"
+              placeholder="your.email@example.com"
+              value={formData.email}
+              onChange={(e) => handleInputChange("email", e.target.value)}
+              className="h-10 sm:h-12 bg-white border-gray-300 text-sm sm:text-base"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="password" className="text-sm sm:text-base font-medium">
+              Password
+            </Label>
+            <div className="relative">
+              <Input
+                id="password"
+                type={showPassword ? "text" : "password"}
+                placeholder="••••••••"
+                value={formData.password}
+                onChange={(e) => handleInputChange("password", e.target.value)}
+                className="h-10 sm:h-12 bg-white border-gray-300 text-sm sm:text-base pr-12"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+              >
+                {showPassword ? <EyeOff className="h-4 w-4 sm:h-5 sm:w-5" /> : <Eye className="h-4 w-4 sm:h-5 sm:w-5" />}
+              </button>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="confirmPassword" className="text-sm sm:text-base font-medium">
+              Confirm Password
+            </Label>
+            <Input
+              id="confirmPassword"
+              type="password"
+              placeholder="••••••••"
+              value={formData.confirmPassword}
+              onChange={(e) => handleInputChange("confirmPassword", e.target.value)}
+              className="h-10 sm:h-12 bg-white border-gray-300 text-sm sm:text-base"
+            />
+          </div>
+
+          <div className="flex items-start">
+            <div className="flex items-center h-5">
+              <input 
+                type="checkbox" 
+                className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded" 
+              />
+            </div>
+            <div className="ml-3 text-sm">
+              <label className="text-gray-900">
+                I agree to the{' '}
+                <a href="#" className="text-blue-600 hover:text-blue-800 hover:underline">
+                  Terms of Service
+                </a>{' '}
+                and{' '}
+                <a href="#" className="text-blue-600 hover:text-blue-800 hover:underline">
+                  Privacy Policy
+                </a>
+              </label>
+            </div>
+          </div>
+
+          <Button
+            type="submit"
+            className="w-full"
+          >
+            Create Account
+          </Button>
+        </form>
+
+        <div className="mt-6 text-center">
+          <p className="text-sm text-gray-600">
+            Already have an account?{' '}
+            <a href="/contributor/auth/login" className="text-blue-600 hover:text-blue-800 hover:underline">
+              Sign in
+            </a>
+          </p>
         </div>
-
-        <div>
-          <label className="block text-sm font-medium text-gray-700">Professional Background</label>
-          <textarea 
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" 
-            rows={3}
-            placeholder="Brief description of your medical/healthcare background"
-          />
-        </div>
-
-        <button 
-          type="submit"
-          className="w-full bg-blue-600 text-white py-3 rounded-md hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-        >
-          Create Account
-        </button>
-      </form>
-
-      <div className="mt-6 text-center">
-        <p className="text-sm text-gray-600">
-          Already have an account?{' '}
-          <a href="/contributor/auth/login" className="text-blue-600 hover:text-blue-800">
-            Sign in here
-          </a>
-        </p>
       </div>
     </div>
   );

--- a/app/layouts/auth-layout.tsx
+++ b/app/layouts/auth-layout.tsx
@@ -4,20 +4,20 @@ export default function AuthLayout() {
   return (
     <div className="min-h-screen">
       {/* Header with back to home */}
-<header className="bg-white border-b border-gray-50 shadow-sm drop-shadow-sm">
+      <header className="bg-white border-b border-gray-50">
         <div className="w-full px-4 sm:px-6 lg:px-8 flex items-center justify-between py-4">
           <Link to="/">
             <img src="/images/logo.png" alt="HealthScope" className="h-10" />
           </Link>
-          <Link 
-            to="/" 
+          <Link
+            to="/"
             className="text-gray-600 hover:text-gray-800 flex items-center gap-2"
           >
             ← Back to Home
           </Link>
         </div>
       </header>
-      
+
       {/* Main auth content */}
       <main>
         <Outlet />

--- a/app/layouts/auth-layout.tsx
+++ b/app/layouts/auth-layout.tsx
@@ -1,21 +1,12 @@
 import { Outlet, Link } from "react-router";
+import Navigation from "~/components/navigation";
 
 export default function AuthLayout() {
   return (
     <div className="min-h-screen">
-      {/* Header with back to home */}
+      {/* Header with navigation */}
       <header className="bg-white border-b border-gray-50">
-        <div className="w-full px-4 sm:px-6 lg:px-8 flex items-center justify-between py-4">
-          <Link to="/">
-            <img src="/images/logo.png" alt="HealthScope" className="h-10" />
-          </Link>
-          <Link
-            to="/"
-            className="text-gray-600 hover:text-gray-800 flex items-center gap-2"
-          >
-            ← Back to Home
-          </Link>
-        </div>
+        <Navigation hideAuthButtons={true} showHomeButton={true} />
       </header>
 
       {/* Main auth content */}

--- a/app/layouts/auth-layout.tsx
+++ b/app/layouts/auth-layout.tsx
@@ -2,10 +2,10 @@ import { Outlet, Link } from "react-router";
 
 export default function AuthLayout() {
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen">
       {/* Header with back to home */}
-      <header className="bg-white border-b">
-        <div className="container flex items-center justify-between py-4">
+<header className="bg-white border-b border-gray-50 shadow-sm drop-shadow-sm">
+        <div className="w-full px-4 sm:px-6 lg:px-8 flex items-center justify-between py-4">
           <Link to="/">
             <img src="/images/logo.png" alt="HealthScope" className="h-10" />
           </Link>
@@ -19,7 +19,7 @@ export default function AuthLayout() {
       </header>
       
       {/* Main auth content */}
-      <main className="flex items-center justify-center py-12">
+      <main>
         <Outlet />
       </main>
     </div>

--- a/app/layouts/partner-dashboard-layout.tsx
+++ b/app/layouts/partner-dashboard-layout.tsx
@@ -16,7 +16,7 @@ export default function PartnerDashboardLayout() {
         </div>
       </nav>
       
-      <main className="min-h-screen bg-gray-50">
+      <main>
         <Outlet />
       </main>
     </>

--- a/app/marketing/components/hero.tsx
+++ b/app/marketing/components/hero.tsx
@@ -11,7 +11,7 @@ const Hero = () => {
           <h1 className="text-2xl md:text-4xl lg:text-5xl xl:text-[56px] font-medium leading-[110%] -tracking-[4%] max-w-none md:max-w-[575px]">
             From quick answers to deep insights
           </h1>
-          <p className="text-base md:text-md lg:text-lg xl:text-[22px] leading-[120%] tracking-[-2%] text-gray-600 max-w-none md:max-w-[540px]">
+          <p className="text-base sm:text-lg leading-[120%] tracking-[-2%] text-gray-600 max-w-none md:max-w-[540px]">
             HealthScope is Africa's first experts-driven health content
             Platform, designed to give you trusted information anytime,
             anywhere.

--- a/app/marketing/pages/articles.tsx
+++ b/app/marketing/pages/articles.tsx
@@ -31,7 +31,7 @@ export default function PublicArticlesPage() {
   const [sortBy, setSortBy] = useState("latest");
   
   // Use the existing auth system
-  const { openSignIn } = usePublicAuth();
+  const { openSignIn, openSignUp } = usePublicAuth();
 
   // Reuse the same filtering logic
   const categories = useMemo(() => {
@@ -153,7 +153,7 @@ export default function PublicArticlesPage() {
         </p>
         <div className="flex flex-col sm:flex-row gap-4 justify-center">
           <button
-            onClick={openSignIn}
+            onClick={openSignUp}
             className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
           >
             Create Free Account

--- a/app/marketing/pages/features.tsx
+++ b/app/marketing/pages/features.tsx
@@ -1,7 +1,7 @@
 
-import type { Route } from "../+types/home";
 import { generateMeta } from "~/lib/meta";
-export function meta({}: Route.MetaArgs) {
+
+export function meta() {
   return generateMeta('features');
 }
 export default function Features() {

--- a/app/marketing/pages/home.tsx
+++ b/app/marketing/pages/home.tsx
@@ -1,4 +1,3 @@
-import type { Route } from "../+types/home";
 import Hero from "~/marketing/components/hero";
 import { PiUsers, PiWarning } from "react-icons/pi";
 import { LuCircleCheckBig } from "react-icons/lu";
@@ -19,7 +18,7 @@ const scopes = [
   }
 ];
 
-export function meta({}: Route.MetaArgs) {
+export function meta() {
   return generateMeta('home');
 }
 
@@ -27,7 +26,7 @@ export default function Home() {
   return (
     <main>
       <Hero />
-      <div className="py-8 md:py-16 lg:py-16">
+      <div className="py-8 md:py-16 lg:py-18">
         <h2 className="font-semibold text-center text-2xl md:text-3xl lg:text-[40px] mb-8 md:mb-12 lg:mb-16 px-4">
           Why HealthScope Matters
         </h2>

--- a/app/marketing/pages/home.tsx
+++ b/app/marketing/pages/home.tsx
@@ -51,7 +51,7 @@ export default function Home() {
                     {scope.title}
                   </h3>
                 </div>
-                <p className="text-sm md:text-[20px] lg:text-[22px] xl:text-[22px] text-gray-600 leading-relaxed">
+                <p className="text-base sm:text-lg text-gray-600 leading-relaxed">
                   {scope.desc}
                 </p>
               </div>
@@ -67,7 +67,7 @@ export default function Home() {
                   The Solution
                 </h3>
               </div>
-              <p className="text-sm md:text-base lg:text-2xl text-gray-500 leading-relaxed max-w-none lg:max-w-[1111px] mb-4 md:mb-6 lg:mb-8">
+              <p className="text-base sm:text-lg text-gray-500 leading-relaxed max-w-none lg:max-w-[1111px] mb-4 md:mb-6 lg:mb-8">
                 HealthScope bridges this gap. We partner with stakeholders in
                 the health value chain to provide accessible health knowledge,
                 making trusted health information easy to find, easy to

--- a/app/partner/auth/login.tsx
+++ b/app/partner/auth/login.tsx
@@ -1,235 +1,252 @@
+"use client"
+
 import { useState } from "react";
-import { X, Eye, EyeOff } from "lucide-react";
 import { Button } from "~/components/ui/button";
-import { Label } from "~/components/ui/label";
-import { Input } from "~/components/ui/input";
-import { useNavigation } from "react-router";
+import { TooltipProvider } from "~/components/ui/tooltip";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import OrganizationDetails from "~/partner/components/organization-details";
+import ContactInformation from "~/partner/components/contact-information";
+import ContactPerson from "~/partner/components/contact-person";
+import LoginForm from "~/partner/components/login-form";
 
-export default function PartnerLogin() {
-	const router = useNavigation()
-	const [showPassword, setShowPassword] = useState(false);
-	const [email, setEmail] = useState("");
-	const [password, setPassword] = useState("");
-	const [isLogin, setIsLogin] = useState(true)
+export default function PartnerAuthPage() {
+  const [showPassword, setShowPassword] = useState(false);
+  const [isOnboarding, setIsOnboarding] = useState(false);
+  const [currentStep, setCurrentStep] = useState(1);
 
-	const handleLogin = (e: React.FormEvent) => {
-		e.preventDefault();
-		// Handle login logic here
-		console.log("[v0] Login attempt with:", { email, password });
-	};
+  const [formData, setFormData] = useState({
+    // Step 1 - Organization Details
+    organizationName: "",
+    type: "",
+    domain: "",
+    country: "",
+    // Step 2 - Contact Information
+    officialEmail: "",
+    phoneNumber: "",
+    website: "",
+    address: "",
+    // Step 3 - Contact Person
+    firstName: "",
+    lastName: "",
+    contactPhone: "",
+    contactEmail: "",
+    // Login
+    loginEmail: "",
+    password: "",
+  });
 
-	return (
-		<div className="min-h-screen bg-[#FAFAFA] flex items-center justify-center p-4">
-			<div className="w-full max-w-6xl bg-white rounded-2xl shadow-sm p-8 md:p-12 lg:p-16 relative">
-				{/* Close button */}
-				<button
-					className="absolute top-6 right-6 text-gray-400 hover:text-gray-600 transition-colors"
-					aria-label="Close"
-					onClick={() => window.location.replace("/") }
-				>
-					<X className="w-6 h-6" />
-				</button>
+  const handleInputChange = (field: string, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
 
-				<div className="grid md:grid-cols-2 gap-12 lg:gap-20">
-					{/* Left side - Information */}
-					<div className="space-y-8">
-						<div className="space-y-6">
-							<h2 className="text-xl font-semibold text-gray-900">
-								Main copy (polished):
-							</h2>
-							<p className="text-gray-700 leading-relaxed">
-								Join a growing network of health organizations, NGOs,
-								public health agencies, and professional bodies bringing
-								expert voices to millions.
-							</p>
-							<p className="text-gray-700 leading-relaxed">
-								With HealthScope, you can invite and manage contributors
-								within your network, publish directly, and track the
-								real-world impact of your work. Together, we can amplify
-								trusted voices and combat health misinformation at
-								scale.
-							</p>
-						</div>
+  const handleNext = () => {
+    if (currentStep < 3) {
+      setCurrentStep(currentStep + 1);
+    }
+  };
 
-						<div className="space-y-4">
-							<h3 className="text-xl font-semibold text-gray-900">
-								Supporting line (credibility):
-							</h3>
-							<p className="text-gray-700 leading-relaxed">
-								Inspired by leading global, African, and governmental
-								health organizations.
-							</p>
-						</div>
+  const handleBack = () => {
+    if (currentStep > 1) {
+      setCurrentStep(currentStep - 1);
+    }
+  };
 
-						<Button
-							onClick={() => setIsLogin(prev => !prev)}
-							className="bg-[#5B7FFF] hover:bg-[#4A6EEE] text-white px-8 py-6 rounded-full text-base font-medium"
-							size="lg"
-						>
-							Become a Partner
-						</Button>
-					</div>
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    console.log("Partner onboarding submitted:", {
+      organizationDetails: {
+        name: formData.organizationName,
+        type: formData.type,
+        domain: formData.domain,
+        country: formData.country,
+      },
+      contactInformation: {
+        email: formData.officialEmail,
+        phone: formData.phoneNumber,
+        website: formData.website,
+        address: formData.address,
+      },
+      contactPerson: {
+        firstName: formData.firstName,
+        lastName: formData.lastName,
+        phone: formData.contactPhone,
+        email: formData.contactEmail,
+      },
+    });
+    // Ready for API integration
+  };
 
-					{/* Right side - Login form */}
-					{isLogin ? (
-						<div className="space-y-6">
-							<h1 className="text-3xl font-bold text-gray-900">
-								Partner Log in
-							</h1>
+  const handleLogin = (e: React.FormEvent) => {
+    e.preventDefault();
+    console.log("Partner login:", {
+      email: formData.loginEmail,
+      password: formData.password,
+    });
+    // Ready for API integration
+  };
 
-							<form onSubmit={handleLogin} className="space-y-6">
-								<div className="space-y-2">
-									<Label
-										htmlFor="email"
-										className="text-base font-medium text-gray-900"
-									>
-										Email/Partner ID
-									</Label>
-									<Input
-										id="email"
-										type="text"
-										placeholder="Enter your email/partner id"
-										value={email}
-										onChange={(e) => setEmail(e.target.value)}
-										className="h-14 px-4 text-base border-gray-300 rounded-lg"
-										required
-									/>
-								</div>
+  const toggleOnboarding = () => {
+    setIsOnboarding(!isOnboarding);
+    setCurrentStep(1);
+  };
 
-								<div className="space-y-2">
-									<Label
-										htmlFor="password"
-										className="text-base font-medium text-gray-900"
-									>
-										Password
-									</Label>
-									<div className="relative">
-										<Input
-											id="password"
-											type={showPassword ? "text" : "password"}
-											placeholder="Enter your password"
-											value={password}
-											onChange={(e) => setPassword(e.target.value)}
-											className="h-14 px-4 pr-12 text-base border-gray-300 rounded-lg"
-											required
-										/>
-										<button
-											type="button"
-											onClick={() => setShowPassword(!showPassword)}
-											className="absolute right-4 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
-											aria-label={
-												showPassword
-													? "Hide password"
-													: "Show password"
-											}
-										>
-											{showPassword ? (
-												<EyeOff className="w-5 h-5" />
-											) : (
-												<Eye className="w-5 h-5" />
-											)}
-										</button>
-									</div>
-								</div>
+  return (
+    <TooltipProvider>
+      <div className="min-h-screen flex flex-col-reverse lg:flex-row">
+        {/* Left Side - Content */}
+        <div className="flex-1 bg-gradient-to-br from-blue-50 to-green-50 p-4 sm:p-6 md:p-8 lg:p-12 xl:p-20 flex flex-col justify-center relative overflow-hidden">
+          {/* Health-themed background illustration */}
+          <div className="absolute inset-0 opacity-10">
+            <svg className="absolute top-10 left-10 w-20 h-20 text-blue-500" fill="currentColor" viewBox="0 0 20 20">
+              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-8.293l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 001.414 1.414L9 9.414V13a1 1 0 102 0V9.414l1.293 1.293a1 1 0 001.414-1.414z" clipRule="evenodd" />
+            </svg>
+            <svg className="absolute bottom-20 right-16 w-16 h-16 text-green-500" fill="currentColor" viewBox="0 0 20 20">
+              <path fillRule="evenodd" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" clipRule="evenodd" />
+            </svg>
+            <svg className="absolute top-1/2 right-1/4 w-12 h-12 text-blue-400" fill="currentColor" viewBox="0 0 20 20">
+              <path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+          </div>
+          
+          <div className="max-w-xl mx-auto lg:mx-0 relative z-10">
+            <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-4 sm:mb-6 text-balance leading-tight">
+              Join a Trusted Health Network
+            </h1>
+            <p className="text-base sm:text-lg mb-6 sm:mb-8 leading-relaxed text-balance text-gray-600">
+              Partner with HealthScope to amplify expert voices, manage health contributors, and combat misinformation at scale.
+            </p>
 
-								<div>
-									<a
-										href="#"
-										className="text-[#5B7FFF] hover:text-[#4A6EEE] text-base font-medium"
-									>
-										Forgot Password?
-									</a>
-								</div>
+            <div className="space-y-3 mb-8 sm:mb-12">
+              <div className="flex items-center gap-3">
+                <div className="w-2 h-2 bg-green-500 rounded-full"></div>
+                <span className="text-gray-700">Trusted by leading health organizations</span>
+              </div>
+              <div className="flex items-center gap-3">
+                <div className="w-2 h-2 bg-blue-500 rounded-full"></div>
+                <span className="text-gray-700">Manage contributors and track impact</span>
+              </div>
+              <div className="flex items-center gap-3">
+                <div className="w-2 h-2 bg-green-500 rounded-full"></div>
+                <span className="text-gray-700">Publish directly to millions</span>
+              </div>
+            </div>
 
-								<Button
-									type="submit"
-									className="w-full bg-[#5B7FFF] hover:bg-[#4A6EEE] text-white h-14 rounded-full text-base font-medium"
-								>
-									Log in
-								</Button>
-							</form>
-						</div>
-					) : (
-						<div className="space-y-6">
-							<h1 className="text-3xl font-bold text-gray-900">
-								Partner Sign In
-							</h1>
+            <Button
+              size="lg"
+              onClick={toggleOnboarding}
+              disabled={isOnboarding}
+              className="bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed text-white px-6 sm:px-8 py-3 sm:py-4 text-sm sm:text-base lg:text-lg w-full sm:w-auto"
+            >
+              {isOnboarding ? "Registration in Progress..." : "Become a Partner"}
+            </Button>
+          </div>
+        </div>
 
-							<form onSubmit={handleLogin} className="space-y-6">
-								<div className="space-y-2">
-									<Label
-										htmlFor="email"
-										className="text-base font-medium text-gray-900"
-									>
-										Email/Partner ID
-									</Label>
-									<Input
-										id="email"
-										type="text"
-										placeholder="Enter your email/partner id"
-										value={email}
-										onChange={(e) => setEmail(e.target.value)}
-										className="h-14 px-4 text-base border-gray-300 rounded-lg"
-										required
-									/>
-								</div>
+        {/* Right Side - Form */}
+        <div className="flex-1 bg-green-50 p-4 sm:p-6 md:p-8 lg:p-12 xl:p-20 flex flex-col justify-center">
+          <div className="max-w-md w-full mx-auto">
+            {!isOnboarding ? (
+              <LoginForm
+                formData={{ loginEmail: formData.loginEmail, password: formData.password }}
+                onInputChange={handleInputChange}
+                onSubmit={handleLogin}
+              />
+            ) : (
+              // Onboarding Form
+              <form onSubmit={handleSubmit} className="space-y-4 sm:space-y-6">
+                <div className="flex items-center justify-between mb-6 sm:mb-8">
+                  <h2 className="text-2xl sm:text-3xl font-bold">Partner Onboarding</h2>
+                  <span className="text-base sm:text-lg font-medium text-gray-600">{currentStep}/3</span>
+                </div>
 
-								<div className="space-y-2">
-									<Label
-										htmlFor="password"
-										className="text-base font-medium text-gray-900"
-									>
-										Password
-									</Label>
-									<div className="relative">
-										<Input
-											id="password"
-											type={showPassword ? "text" : "password"}
-											placeholder="Enter your password"
-											value={password}
-											onChange={(e) => setPassword(e.target.value)}
-											className="h-14 px-4 pr-12 text-base border-gray-300 rounded-lg"
-											required
-										/>
-										<button
-											type="button"
-											onClick={() => setShowPassword(!showPassword)}
-											className="absolute right-4 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
-											aria-label={
-												showPassword
-													? "Hide password"
-													: "Show password"
-											}
-										>
-											{showPassword ? (
-												<EyeOff className="w-5 h-5" />
-											) : (
-												<Eye className="w-5 h-5" />
-											)}
-										</button>
-									</div>
-								</div>
+                {/* Step 1: Organization Details */}
+                {currentStep === 1 && (
+                  <>
+                    <OrganizationDetails
+                      formData={{
+                        organizationName: formData.organizationName,
+                        type: formData.type,
+                        domain: formData.domain,
+                        country: formData.country,
+                      }}
+                      onInputChange={handleInputChange}
+                    />
+                    
+                    {/* Already have account link */}
+                    <div className="pt-4 text-center">
+                      <button
+                        type="button"
+                        onClick={toggleOnboarding}
+                        className="text-blue-600 hover:text-blue-800 hover:underline text-xs sm:text-sm font-medium"
+                      >
+                        Already have an account? Login
+                      </button>
+                    </div>
+                  </>
+                )}
 
-								<div>
-									<a
-										href="#"
-										className="text-[#5B7FFF] hover:text-[#4A6EEE] text-base font-medium"
-									>
-										Forgot Password?
-									</a>
-								</div>
+                {/* Step 2: Contact Information */}
+                {currentStep === 2 && (
+                  <ContactInformation
+                    formData={{
+                      officialEmail: formData.officialEmail,
+                      phoneNumber: formData.phoneNumber,
+                      website: formData.website,
+                      address: formData.address,
+                    }}
+                    onInputChange={handleInputChange}
+                  />
+                )}
 
-								<Button
-									type="submit"
-									className="w-full bg-[#5B7FFF] hover:bg-[#4A6EEE] text-white h-14 rounded-full text-base font-medium"
-								>
-									Log in
-								</Button>
-							</form>
-						</div>
-					)}
-				</div>
-			</div>
-		</div>
-	);
+                {/* Step 3: Contact Person */}
+                {currentStep === 3 && (
+                  <ContactPerson
+                    formData={{
+                      firstName: formData.firstName,
+                      lastName: formData.lastName,
+                      contactPhone: formData.contactPhone,
+                      contactEmail: formData.contactEmail,
+                    }}
+                    onInputChange={handleInputChange}
+                  />
+                )}
+
+                {/* Navigation Buttons */}
+                <div className="flex gap-3 sm:gap-4 pt-4 sm:pt-6">
+                  {currentStep > 1 && (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={handleBack}
+                      className="flex-1 h-10 sm:h-12 bg-transparent border-gray-300 text-gray-700 text-sm sm:text-base"
+                    >
+                      <ArrowLeft className="h-4 w-4 mr-2" />
+                      Back
+                    </Button>
+                  )}
+                  {currentStep < 3 ? (
+                    <Button
+                      type="button"
+                      onClick={handleNext}
+                      className="flex-1 bg-blue-600 hover:bg-blue-700 text-white h-10 sm:h-12 text-sm sm:text-base"
+                    >
+                      Next
+                      <ArrowRight className="h-4 w-4 ml-2" />
+                    </Button>
+                  ) : (
+                    <Button
+                      type="submit"
+                      className="flex-1 bg-blue-600 hover:bg-blue-700 text-white h-10 sm:h-12 text-sm sm:text-base"
+                    >
+                      Complete Onboarding
+                    </Button>
+                  )}
+                </div>
+              </form>
+            )}
+          </div>
+        </div>
+      </div>
+    </TooltipProvider>
+  );
 }

--- a/app/partner/auth/login.tsx
+++ b/app/partner/auth/login.tsx
@@ -92,7 +92,7 @@ export default function PartnerAuthPage() {
 
   return (
     <TooltipProvider>
-      <div className="min-h-screen flex flex-col-reverse lg:flex-row">
+      <div className="h-[90vh] flex flex-col-reverse lg:flex-row">
         {/* Left Side - Content */}
         <div className="flex-1 bg-gradient-to-br from-blue-50 to-green-50 p-4 sm:p-6 md:p-8 lg:p-12 xl:p-20 flex flex-col justify-center relative overflow-hidden">
           {/* Health-themed background illustration */}

--- a/app/partner/auth/login.tsx
+++ b/app/partner/auth/login.tsx
@@ -1,7 +1,7 @@
-"use client"
+"use client";
 
 import { useState } from "react";
-import { Button } from "~/components/ui/button";
+import Button from "~/components/button";
 import { TooltipProvider } from "~/components/ui/tooltip";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import OrganizationDetails from "~/partner/components/organization-details";
@@ -97,47 +97,73 @@ export default function PartnerAuthPage() {
         <div className="flex-1 bg-gradient-to-br from-blue-50 to-green-50 p-4 sm:p-6 md:p-8 lg:p-12 xl:p-20 flex flex-col justify-center relative overflow-hidden">
           {/* Health-themed background illustration */}
           <div className="absolute inset-0 opacity-10">
-            <svg className="absolute top-10 left-10 w-20 h-20 text-blue-500" fill="currentColor" viewBox="0 0 20 20">
-              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-8.293l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 001.414 1.414L9 9.414V13a1 1 0 102 0V9.414l1.293 1.293a1 1 0 001.414-1.414z" clipRule="evenodd" />
+            <svg
+              className="absolute top-10 left-10 w-20 h-20 text-blue-500"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+            >
+              <path
+                fillRule="evenodd"
+                d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-8.293l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 001.414 1.414L9 9.414V13a1 1 0 102 0V9.414l1.293 1.293a1 1 0 001.414-1.414z"
+                clipRule="evenodd"
+              />
             </svg>
-            <svg className="absolute bottom-20 right-16 w-16 h-16 text-green-500" fill="currentColor" viewBox="0 0 20 20">
-              <path fillRule="evenodd" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" clipRule="evenodd" />
+            <svg
+              className="absolute bottom-20 right-16 w-16 h-16 text-green-500"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+            >
+              <path
+                fillRule="evenodd"
+                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                clipRule="evenodd"
+              />
             </svg>
-            <svg className="absolute top-1/2 right-1/4 w-12 h-12 text-blue-400" fill="currentColor" viewBox="0 0 20 20">
+            <svg
+              className="absolute top-1/2 right-1/4 w-12 h-12 text-blue-400"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+            >
               <path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
           </div>
-          
+
           <div className="max-w-xl mx-auto lg:mx-0 relative z-10">
             <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-4 sm:mb-6 text-balance leading-tight">
-              Join a Trusted Health Network
+              Join a Trusted Partner Network
             </h1>
             <p className="text-base sm:text-lg mb-6 sm:mb-8 leading-relaxed text-balance text-gray-600">
-              Partner with HealthScope to amplify expert voices, manage health contributors, and combat misinformation at scale.
+              Partner with HealthScope to amplify expert voices, manage health
+              contributors, and combat misinformation at scale.
             </p>
 
             <div className="space-y-3 mb-8 sm:mb-12">
               <div className="flex items-center gap-3">
                 <div className="w-2 h-2 bg-green-500 rounded-full"></div>
-                <span className="text-gray-700">Trusted by leading health organizations</span>
+                <span className="text-gray-700">
+                  Trusted by leading health organizations
+                </span>
               </div>
               <div className="flex items-center gap-3">
                 <div className="w-2 h-2 bg-blue-500 rounded-full"></div>
-                <span className="text-gray-700">Manage contributors and track impact</span>
+                <span className="text-gray-700">
+                  Manage contributors and track impact
+                </span>
               </div>
               <div className="flex items-center gap-3">
                 <div className="w-2 h-2 bg-green-500 rounded-full"></div>
-                <span className="text-gray-700">Publish directly to millions</span>
+                <span className="text-gray-700">
+                  Publish directly to millions
+                </span>
               </div>
             </div>
 
             <Button
-              size="lg"
               onClick={toggleOnboarding}
               disabled={isOnboarding}
-              className="bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed text-white px-6 sm:px-8 py-3 sm:py-4 text-sm sm:text-base lg:text-lg w-full sm:w-auto"
+              className="shrink-0"
             >
-              {isOnboarding ? "Registration in Progress..." : "Become a Partner"}
+              {isOnboarding ? "Starting..." : "Become a Partner"}
             </Button>
           </div>
         </div>
@@ -147,7 +173,10 @@ export default function PartnerAuthPage() {
           <div className="max-w-md w-full mx-auto">
             {!isOnboarding ? (
               <LoginForm
-                formData={{ loginEmail: formData.loginEmail, password: formData.password }}
+                formData={{
+                  loginEmail: formData.loginEmail,
+                  password: formData.password,
+                }}
                 onInputChange={handleInputChange}
                 onSubmit={handleLogin}
               />
@@ -155,8 +184,12 @@ export default function PartnerAuthPage() {
               // Onboarding Form
               <form onSubmit={handleSubmit} className="space-y-4 sm:space-y-6">
                 <div className="flex items-center justify-between mb-6 sm:mb-8">
-                  <h2 className="text-2xl sm:text-3xl font-bold">Partner Onboarding</h2>
-                  <span className="text-base sm:text-lg font-medium text-gray-600">{currentStep}/3</span>
+                  <h2 className="text-2xl sm:text-3xl font-bold">
+                    Partner Onboarding
+                  </h2>
+                  <span className="text-base sm:text-lg font-medium text-gray-600">
+                    {currentStep}/3
+                  </span>
                 </div>
 
                 {/* Step 1: Organization Details */}
@@ -171,7 +204,7 @@ export default function PartnerAuthPage() {
                       }}
                       onInputChange={handleInputChange}
                     />
-                    
+
                     {/* Already have account link */}
                     <div className="pt-4 text-center">
                       <button
@@ -212,33 +245,39 @@ export default function PartnerAuthPage() {
                 )}
 
                 {/* Navigation Buttons */}
-                <div className="flex gap-3 sm:gap-4 pt-4 sm:pt-6">
+                <div className="flex justify-between gap-3 sm:gap-4 pt-4 sm:pt-6">
                   {currentStep > 1 && (
                     <Button
                       type="button"
                       variant="outline"
                       onClick={handleBack}
-                      className="flex-1 h-10 sm:h-12 bg-transparent border-gray-300 text-gray-700 text-sm sm:text-base"
+                      className="flex-[0.4] px-6 flex items-center justify-center gap-2 h-10 sm:h-12"
                     >
-                      <ArrowLeft className="h-4 w-4 mr-2" />
-                      Back
+                      <div className="flex items-center justify-center gap-2">
+                        <ArrowLeft className="h-4 w-4" />
+                        <span>Back</span>
+                      </div>
                     </Button>
                   )}
                   {currentStep < 3 ? (
                     <Button
                       type="button"
                       onClick={handleNext}
-                      className="flex-1 bg-blue-600 hover:bg-blue-700 text-white h-10 sm:h-12 text-sm sm:text-base"
+                      className="flex-[0.4] px-6 flex items-center justify-center gap-2 h-10 sm:h-12"
                     >
-                      Next
-                      <ArrowRight className="h-4 w-4 ml-2" />
+                      <div className="flex items-center justify-center gap-2">
+                        <span>Next</span>
+                        <ArrowRight className="h-4 w-4" />
+                      </div>
                     </Button>
                   ) : (
                     <Button
                       type="submit"
-                      className="flex-1 bg-blue-600 hover:bg-blue-700 text-white h-10 sm:h-12 text-sm sm:text-base"
+                      className="flex-[0.4] px-8 flex items-center justify-center h-10 sm:h-12"
                     >
-                      Complete Onboarding
+                      <div className="flex items-center justify-center">
+                        <span>Submit</span>
+                      </div>
                     </Button>
                   )}
                 </div>

--- a/app/partner/components/contact-information.tsx
+++ b/app/partner/components/contact-information.tsx
@@ -1,0 +1,90 @@
+import { Label } from "~/components/ui/label";
+import { Input } from "~/components/ui/input";
+import { Textarea } from "~/components/ui/textarea";
+import { Tooltip, TooltipContent, TooltipTrigger } from "~/components/ui/tooltip";
+import { Info } from "lucide-react";
+
+interface ContactInformationProps {
+  formData: {
+    officialEmail: string;
+    phoneNumber: string;
+    website: string;
+    address: string;
+  };
+  onInputChange: (field: string, value: string) => void;
+}
+
+export default function ContactInformation({ formData, onInputChange }: ContactInformationProps) {
+  return (
+    <div className="space-y-4 sm:space-y-6">
+      <div className="flex items-center gap-2 mb-4 sm:mb-6">
+        <h3 className="text-lg sm:text-xl font-semibold">Contact Information</h3>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button type="button" className="text-gray-500 hover:text-gray-700">
+              <Info className="h-4 w-4" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Provide your official contact details</p>
+          </TooltipContent>
+        </Tooltip>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="officialEmail" className="text-sm sm:text-base font-medium">
+          Official Email
+        </Label>
+        <Input
+          id="officialEmail"
+          type="email"
+          value={formData.officialEmail}
+          onChange={(e) => onInputChange("officialEmail", e.target.value)}
+          className="h-10 sm:h-12 bg-white border-gray-300 text-sm sm:text-base"
+          placeholder="Enter official email"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="phoneNumber" className="text-sm sm:text-base font-medium">
+          Phone Number
+        </Label>
+        <Input
+          id="phoneNumber"
+          type="tel"
+          value={formData.phoneNumber}
+          onChange={(e) => onInputChange("phoneNumber", e.target.value)}
+          className="h-10 sm:h-12 bg-white border-gray-300 text-sm sm:text-base"
+          placeholder="Enter phone number"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="website" className="text-sm sm:text-base font-medium">
+          Website
+        </Label>
+        <Input
+          id="website"
+          type="url"
+          value={formData.website}
+          onChange={(e) => onInputChange("website", e.target.value)}
+          className="h-10 sm:h-12 bg-white border-gray-300 text-sm sm:text-base"
+          placeholder="Enter website URL"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="address" className="text-sm sm:text-base font-medium">
+          Address
+        </Label>
+        <Textarea
+          id="address"
+          value={formData.address}
+          onChange={(e) => onInputChange("address", e.target.value)}
+          className="bg-white border-gray-300 min-h-20 sm:min-h-24 resize-none text-sm sm:text-base"
+          placeholder="Enter organization address"
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/partner/components/contact-information.tsx
+++ b/app/partner/components/contact-information.tsx
@@ -1,8 +1,12 @@
 import { Label } from "~/components/ui/label";
 import { Input } from "~/components/ui/input";
 import { Textarea } from "~/components/ui/textarea";
-import { Tooltip, TooltipContent, TooltipTrigger } from "~/components/ui/tooltip";
-import { Info } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "~/components/ui/tooltip";
+import { FcInfo } from "react-icons/fc";
 
 interface ContactInformationProps {
   formData: {
@@ -14,16 +18,19 @@ interface ContactInformationProps {
   onInputChange: (field: string, value: string) => void;
 }
 
-export default function ContactInformation({ formData, onInputChange }: ContactInformationProps) {
+export default function ContactInformation({
+  formData,
+  onInputChange,
+}: ContactInformationProps) {
   return (
     <div className="space-y-4 sm:space-y-6">
       <div className="flex items-center gap-2 mb-4 sm:mb-6">
-        <h3 className="text-lg sm:text-xl font-semibold">Contact Information</h3>
+        <h3 className="text-lg sm:text-xl font-semibold">
+          Contact Information
+        </h3>
         <Tooltip>
           <TooltipTrigger asChild>
-            <button type="button" className="text-gray-500 hover:text-gray-700">
-              <Info className="h-4 w-4" />
-            </button>
+            <FcInfo className="w-4.5 h-4.5" />
           </TooltipTrigger>
           <TooltipContent>
             <p>Provide your official contact details</p>
@@ -32,7 +39,10 @@ export default function ContactInformation({ formData, onInputChange }: ContactI
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor="officialEmail" className="text-sm sm:text-base font-medium">
+        <Label
+          htmlFor="officialEmail"
+          className="text-sm sm:text-base font-medium"
+        >
           Official Email
         </Label>
         <Input
@@ -46,7 +56,10 @@ export default function ContactInformation({ formData, onInputChange }: ContactI
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor="phoneNumber" className="text-sm sm:text-base font-medium">
+        <Label
+          htmlFor="phoneNumber"
+          className="text-sm sm:text-base font-medium"
+        >
           Phone Number
         </Label>
         <Input

--- a/app/partner/components/contact-person.tsx
+++ b/app/partner/components/contact-person.tsx
@@ -1,7 +1,7 @@
 import { Label } from "~/components/ui/label";
 import { Input } from "~/components/ui/input";
 import { Tooltip, TooltipContent, TooltipTrigger } from "~/components/ui/tooltip";
-import { Info } from "lucide-react";
+import { FcInfo } from "react-icons/fc";
 
 interface ContactPersonProps {
   formData: {
@@ -20,9 +20,7 @@ export default function ContactPerson({ formData, onInputChange }: ContactPerson
         <h3 className="text-lg sm:text-xl font-semibold">Contact Person</h3>
         <Tooltip>
           <TooltipTrigger asChild>
-            <button type="button" className="text-gray-500 hover:text-gray-700">
-              <Info className="h-4 w-4" />
-            </button>
+            <FcInfo className="w-4.5 h-4.5" />
           </TooltipTrigger>
           <TooltipContent>
             <p>Who should we reach out to regarding this partnership?</p>

--- a/app/partner/components/contact-person.tsx
+++ b/app/partner/components/contact-person.tsx
@@ -1,0 +1,88 @@
+import { Label } from "~/components/ui/label";
+import { Input } from "~/components/ui/input";
+import { Tooltip, TooltipContent, TooltipTrigger } from "~/components/ui/tooltip";
+import { Info } from "lucide-react";
+
+interface ContactPersonProps {
+  formData: {
+    firstName: string;
+    lastName: string;
+    contactPhone: string;
+    contactEmail: string;
+  };
+  onInputChange: (field: string, value: string) => void;
+}
+
+export default function ContactPerson({ formData, onInputChange }: ContactPersonProps) {
+  return (
+    <div className="space-y-4 sm:space-y-6">
+      <div className="flex items-center gap-2 mb-4 sm:mb-6">
+        <h3 className="text-lg sm:text-xl font-semibold">Contact Person</h3>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button type="button" className="text-gray-500 hover:text-gray-700">
+              <Info className="h-4 w-4" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Who should we reach out to regarding this partnership?</p>
+          </TooltipContent>
+        </Tooltip>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="firstName" className="text-sm sm:text-base font-medium">
+          First Name
+        </Label>
+        <Input
+          id="firstName"
+          value={formData.firstName}
+          onChange={(e) => onInputChange("firstName", e.target.value)}
+          className="h-10 sm:h-12 bg-white border-gray-300 text-sm sm:text-base"
+          placeholder="Enter first name"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="lastName" className="text-sm sm:text-base font-medium">
+          Last Name
+        </Label>
+        <Input
+          id="lastName"
+          value={formData.lastName}
+          onChange={(e) => onInputChange("lastName", e.target.value)}
+          className="h-10 sm:h-12 bg-white border-gray-300 text-sm sm:text-base"
+          placeholder="Enter last name"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="contactPhone" className="text-sm sm:text-base font-medium">
+          Phone
+        </Label>
+        <Input
+          id="contactPhone"
+          type="tel"
+          value={formData.contactPhone}
+          onChange={(e) => onInputChange("contactPhone", e.target.value)}
+          className="h-10 sm:h-12 bg-white border-gray-300 text-sm sm:text-base"
+          placeholder="Enter phone number"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="contactEmail" className="text-sm sm:text-base font-medium">
+          Email
+        </Label>
+        <Input
+          id="contactEmail"
+          type="email"
+          value={formData.contactEmail}
+          onChange={(e) => onInputChange("contactEmail", e.target.value)}
+          className="h-10 sm:h-12 bg-white border-gray-300 text-sm sm:text-base"
+          placeholder="Enter email address"
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/partner/components/login-form.tsx
+++ b/app/partner/components/login-form.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Button } from "~/components/ui/button";
+import Button from "~/components/button";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { Eye, EyeOff } from "lucide-react";
@@ -65,8 +65,7 @@ export default function LoginForm({ formData, onInputChange, onSubmit }: LoginFo
 
       <Button
         type="submit"
-        size="lg"
-        className="w-full bg-blue-600 hover:bg-blue-700 text-white h-10 sm:h-12 text-sm sm:text-base"
+        className="w-full"
       >
         Log in
       </Button>

--- a/app/partner/components/login-form.tsx
+++ b/app/partner/components/login-form.tsx
@@ -1,0 +1,75 @@
+import { useState } from "react";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { Eye, EyeOff } from "lucide-react";
+
+interface LoginFormProps {
+  formData: {
+    loginEmail: string;
+    password: string;
+  };
+  onInputChange: (field: string, value: string) => void;
+  onSubmit: (e: React.FormEvent) => void;
+}
+
+export default function LoginForm({ formData, onInputChange, onSubmit }: LoginFormProps) {
+  const [showPassword, setShowPassword] = useState(false);
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4 sm:space-y-6">
+      <h2 className="text-2xl sm:text-3xl font-bold mb-6 sm:mb-8">Partner Log in</h2>
+
+      <div className="space-y-2">
+        <Label htmlFor="loginEmail" className="text-sm sm:text-base font-medium">
+          Email/Partner ID
+        </Label>
+        <Input
+          id="loginEmail"
+          type="text"
+          placeholder="Enter your email/partner id"
+          value={formData.loginEmail}
+          onChange={(e) => onInputChange("loginEmail", e.target.value)}
+          className="h-10 sm:h-12 bg-white border-gray-300 text-sm sm:text-base"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="password" className="text-sm sm:text-base font-medium">
+          Password
+        </Label>
+        <div className="relative">
+          <Input
+            id="password"
+            type={showPassword ? "text" : "password"}
+            placeholder="Enter your password"
+            value={formData.password}
+            onChange={(e) => onInputChange("password", e.target.value)}
+            className="h-10 sm:h-12 bg-white border-gray-300 text-sm sm:text-base pr-12"
+          />
+          <button
+            type="button"
+            onClick={() => setShowPassword(!showPassword)}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+          >
+            {showPassword ? <EyeOff className="h-4 w-4 sm:h-5 sm:w-5" /> : <Eye className="h-4 w-4 sm:h-5 sm:w-5" />}
+          </button>
+        </div>
+      </div>
+
+      <div>
+        <a href="#" className="text-blue-600 hover:text-blue-800 hover:underline text-xs sm:text-sm font-medium">
+          Forgot Password?
+        </a>
+      </div>
+
+      <Button
+        type="submit"
+        size="lg"
+        className="w-full bg-blue-600 hover:bg-blue-700 text-white h-10 sm:h-12 text-sm sm:text-base"
+      >
+        Log in
+      </Button>
+    </form>
+  );
+}

--- a/app/partner/components/organization-details.tsx
+++ b/app/partner/components/organization-details.tsx
@@ -1,0 +1,113 @@
+import { Label } from "~/components/ui/label";
+import { Input } from "~/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/components/ui/select";
+import { Tooltip, TooltipContent, TooltipTrigger } from "~/components/ui/tooltip";
+import { Info } from "lucide-react";
+
+const organizationTypes = ["NGO", "Foundation", "Government", "Association", "Research Institute", "Others"];
+
+const domains = [
+  "General Health",
+  "Communicable & Infectious Diseases",
+  "Non-Communicable Diseases (NCDs)",
+  "Maternal, Newborn, Child & Adolescent Health",
+  "Nutrition & Food Security",
+  "Environmental & Occupational Health",
+  "Sexual & Reproductive Health and Rights (SRHR)",
+  "Health Systems Strengthening",
+  "Emergency Preparedness & Humanitarian Health",
+  "Aging & Geriatric Health",
+  "Cross-Cutting & Emerging Areas",
+];
+
+interface OrganizationDetailsProps {
+  formData: {
+    organizationName: string;
+    type: string;
+    domain: string;
+    country: string;
+  };
+  onInputChange: (field: string, value: string) => void;
+}
+
+export default function OrganizationDetails({ formData, onInputChange }: OrganizationDetailsProps) {
+  return (
+    <div className="space-y-4 sm:space-y-6">
+      <div className="flex items-center gap-2 mb-4 sm:mb-6">
+        <h3 className="text-lg sm:text-xl font-semibold">Organization Details</h3>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button type="button" className="text-gray-500 hover:text-gray-700">
+              <Info className="h-4 w-4" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Tell us about your organization&apos;s identity and focus.</p>
+          </TooltipContent>
+        </Tooltip>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="orgName" className="text-sm sm:text-base font-medium">
+          Organization Name
+        </Label>
+        <Input
+          id="orgName"
+          value={formData.organizationName}
+          onChange={(e) => onInputChange("organizationName", e.target.value)}
+          className="h-10 sm:h-12 bg-white border-gray-300 text-sm sm:text-base"
+          placeholder="Enter organization name"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="type" className="text-sm sm:text-base font-medium">
+          Type
+        </Label>
+        <Select value={formData.type} onValueChange={(value) => onInputChange("type", value)}>
+          <SelectTrigger className="h-10 sm:h-12 bg-white border-gray-300 text-sm sm:text-base">
+            <SelectValue placeholder="Select organization type" />
+          </SelectTrigger>
+          <SelectContent>
+            {organizationTypes.map((type) => (
+              <SelectItem key={type} value={type}>
+                {type}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="domain" className="text-sm sm:text-base font-medium">
+          Domain/Industry
+        </Label>
+        <Select value={formData.domain} onValueChange={(value) => onInputChange("domain", value)}>
+          <SelectTrigger className="h-10 sm:h-12 bg-white border-gray-300 text-sm sm:text-base">
+            <SelectValue placeholder="Select domain" />
+          </SelectTrigger>
+          <SelectContent>
+            {domains.map((domain) => (
+              <SelectItem key={domain} value={domain}>
+                {domain}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="country" className="text-sm sm:text-base font-medium">
+          Country
+        </Label>
+        <Input
+          id="country"
+          value={formData.country}
+          onChange={(e) => onInputChange("country", e.target.value)}
+          className="h-10 sm:h-12 bg-white border-gray-300 text-sm sm:text-base"
+          placeholder="Enter country"
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/partner/components/organization-details.tsx
+++ b/app/partner/components/organization-details.tsx
@@ -2,7 +2,7 @@ import { Label } from "~/components/ui/label";
 import { Input } from "~/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/components/ui/select";
 import { Tooltip, TooltipContent, TooltipTrigger } from "~/components/ui/tooltip";
-import { Info } from "lucide-react";
+import { FcInfo } from "react-icons/fc";
 
 const organizationTypes = ["NGO", "Foundation", "Government", "Association", "Research Institute", "Others"];
 
@@ -37,9 +37,7 @@ export default function OrganizationDetails({ formData, onInputChange }: Organiz
         <h3 className="text-lg sm:text-xl font-semibold">Organization Details</h3>
         <Tooltip>
           <TooltipTrigger asChild>
-            <button type="button" className="text-gray-500 hover:text-gray-700">
-              <Info className="h-4 w-4" />
-            </button>
+            <FcInfo className="w-4.5 h-4.5" />
           </TooltipTrigger>
           <TooltipContent>
             <p>Tell us about your organization&apos;s identity and focus.</p>

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -13,6 +13,8 @@ export default [
   // Auth pages with auth layout
   layout("layouts/auth-layout.tsx", [
     route("partner/auth/login", "partner/auth/login.tsx"),
+    route("contributor/auth/login", "contributor/auth/login.tsx"),
+    route("contributor/auth/signup", "contributor/auth/signup.tsx"),
   ]),
 
   // Reader dashboard routes

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-tooltip": "^1.2.8",
         "@react-router/node": "^7.7.1",
         "@react-router/serve": "^7.7.1",
         "@uidotdev/usehooks": "^2.4.1",
@@ -1678,6 +1679,40 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@react-router/node": "^7.7.1",
     "@react-router/serve": "^7.7.1",
     "@uidotdev/usehooks": "^2.4.1",


### PR DESCRIPTION
* Implement partner auth page
* Style partner auth page
* Add contributor login page
* Update contributor auth pages to use `auth-layout` with full navigation
* Add props-based navigation control (`hideAuthButtons`, `showHomeButton`)
* Apply partner page styling to contributor login (gradient background, centered layout)
* Replace auth buttons with a Home button on auth pages
* Fix `usePublicAuth` context error with safe hook usage
* Improve partner onboarding button styles and tooltip icons
* Add `FcInfo` icons across partner components for consistency
